### PR TITLE
Made type aliases public to fix compiler warnings

### DIFF
--- a/Bayes/BayesianClassifier.swift
+++ b/Bayes/BayesianClassifier.swift
@@ -11,8 +11,8 @@ import Foundation
 let nonZeroLog = 0.00000001
 
 public struct BayesianClassifier<C :Hashable, F :Hashable> {
-    typealias Feature = F
-    typealias Category = C
+    public typealias Feature = F
+    public typealias Category = C
     
     public init(eventSpace: EventSpace<Category,Feature>){
         self.eventSpace = eventSpace

--- a/Bayes/EventSpace.swift
+++ b/Bayes/EventSpace.swift
@@ -7,8 +7,8 @@
 //
 
 public struct EventSpace <C: Hashable, F: Hashable> {
-    typealias Category = C
-    typealias Feature = F
+    public typealias Category = C
+    public typealias Feature = F
     
     public init() {}
     


### PR DESCRIPTION
The project fails to compile becuase the type aliases are not public. The solution is to simply make them visbile outside the module.
