### PR TITLE
Hash fix

### DIFF
--- a/Bayes/EventSpace.swift
+++ b/Bayes/EventSpace.swift
@@ -20,18 +20,18 @@ public struct EventSpace <C: Hashable, F: Hashable> {
     
     private var _categories :Bag<C> = Bag<C>()
     private var _features :Bag<F> = Bag<F>()
-    private var featureCategory :Bag<HashableTouple<C,F>> = Bag<HashableTouple<C,F>>()
+    private var featureCategory :Bag<HashableTuple<C,F>> = Bag<HashableTuple<C,F>>()
     
     public mutating func observe <F: SequenceType where F.Generator.Element == Feature> (category: Category, features: F) {
         _categories.append(category)
         _features.append(features)
         featureCategory.append(features.map {
-            HashableTouple(category,$0)
+            HashableTuple(category,$0)
         })
     }
     
     public func P(feature: Feature, andCategory category: Category) -> Double {
-        return Double(featureCategory.count(HashableTouple(category, feature))) / Double(_categories.count)
+        return Double(featureCategory.count(HashableTuple(category, feature))) / Double(_categories.count)
     }
     
     public func P(feature: Feature, givenCategory category: Category) -> Double {

--- a/Bayes/HashableTouple.swift
+++ b/Bayes/HashableTouple.swift
@@ -20,7 +20,7 @@ internal struct HashableTouple<A : Hashable, B : Hashable> : Hashable {
     
     var hashValue :Int {
         get {
-            return (a.hashValue >> 2 ^ b.hashValue << 2) + (b.hashValue << 5 + a.hashValue >> 5)
+            return a.hashValue ^ b.hashValue
         }
     }
 }

--- a/Bayes/HashableTouple.swift
+++ b/Bayes/HashableTouple.swift
@@ -1,5 +1,5 @@
 //
-//  HashableTouple.swift
+//  HashableTuple.swift
 //  Bayes
 //
 //  Created by Fabian Canas on 5/9/15.
@@ -9,7 +9,7 @@
 /** A (Hashable, Hashable) isn't Hashable. But it sure makes it easier to
 represent conditional probilities in a Set or Dictionary if they are
 */
-internal struct HashableTouple<A : Hashable, B : Hashable> : Hashable {
+internal struct HashableTuple<A : Hashable, B : Hashable> : Hashable {
     let a :A
     let b :B
     
@@ -25,6 +25,6 @@ internal struct HashableTouple<A : Hashable, B : Hashable> : Hashable {
     }
 }
 
-internal func == <A, B> (lhs: HashableTouple<A,B>, rhs: HashableTouple<A,B>) -> Bool {
+internal func == <A, B> (lhs: HashableTuple<A,B>, rhs: HashableTuple<A,B>) -> Bool {
     return lhs.a == rhs.a && lhs.b == rhs.b
 }


### PR DESCRIPTION
- Prevents an Integer overflow, by modifing the hashing function. This bug is only present on 32bit devices (pre iPhone 5S)
- This patch fixes a typo "touple" -> "Tuple"
