### PR TITLE
Ignore Xcode project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ fastlane/test_output
 iOSInjectionProject/
 .DS_Store
 .build
+Bayes.xcodeproj

--- a/Sources/BayesianClassifier.swift
+++ b/Sources/BayesianClassifier.swift
@@ -13,19 +13,19 @@ private let nonZeroLog = 0.00000001
 public struct BayesianClassifier<C :Hashable, F :Hashable> {
     public typealias Feature = F
     public typealias Category = C
-    
+
     /// Initializes a new BayesianClassifier with an empty EventSpace
     public init(){ }
-    
+
     /// Initializes a new BayesianClassifier with an existing EventSpace
     ///
     /// - Parameter eventSpace: an EventSpace of Features and Categories
     public init(eventSpace: EventSpace<Category,Feature>){
         self.eventSpace = eventSpace
     }
-    
+
     public var eventSpace :EventSpace<Category,Feature> = EventSpace<Category,Feature>()
-    
+
     /// The most likely category given a sequence of Features
     ///
     /// - Parameter features: A Sequence of observed Features
@@ -33,8 +33,8 @@ public struct BayesianClassifier<C :Hashable, F :Hashable> {
     public func classify <S :Sequence> (_ features :S) -> Category? where S.Iterator.Element == Feature {
         return argmax(categoryProbabilities(features))
     }
-    
-    /// The propbability of each known Category given a sequence of Features
+
+    /// The probability of each known Category given a sequence of Features
     ///
     /// - Parameter features: A sequence of features
     /// - Returns: A dictionary mapping each known Category to a probability of

--- a/Sources/HashableTuple.swift
+++ b/Sources/HashableTuple.swift
@@ -8,7 +8,7 @@
 
 /** 
  A (Hashable, Hashable) isn't Hashable. But representing conditional
- probilities in a Set or Dictionary is easier if they are.
+ probabilities in a Set or Dictionary is easier if they are.
 */
 internal struct HashableTuple<A : Hashable, B : Hashable> : Hashable {
     let a :A


### PR DESCRIPTION
Now that Bayes is using swiftpm, there's not need to maintain a project file in the repository.
One can be generated from the command line, but it's not going to be checked in.

Neither CI, swiftpm, nor CocoaPods relies on any information from Xcode.